### PR TITLE
simple fix

### DIFF
--- a/HAMLET.cpp
+++ b/HAMLET.cpp
@@ -25,7 +25,7 @@ public:
     return *this;
   }
 
-  char const* what() const
+  char const* what() const noexcept override
   {
     mStr = mSS->str();
     return mStr.c_str();


### PR DESCRIPTION
In C++11 and later, the what() method in std::exception is declared with noexcept (which is the same as _GLIBCXX_NOTHROW in the error message), but your implementation doesn't have this specification.